### PR TITLE
created SeasonLogForm component to start a new season log

### DIFF
--- a/src/components/ApplicationViews.jsx
+++ b/src/components/ApplicationViews.jsx
@@ -6,6 +6,7 @@ import Home from "../pages/Home"
 import { SeasonLogsList } from "./season-logs/SeasonLogsList"
 import { NavBar } from "./Navbar"
 import { SeasonLogDetail } from "./season-logs/SeasonLogDetail"
+import { SeasonLogForm } from "./season-logs/SeasonLogForm"
 
 export const ApplicationViews = () => {
     return (
@@ -20,7 +21,7 @@ export const ApplicationViews = () => {
                         <Route path="/season-logs"> 
                             <Route index element={<SeasonLogsList />} />
                             <Route path=":seasonLogId" element={<SeasonLogDetail />} />
-                            <Route path="create" element={<>Start a Season Log</>} />
+                            <Route path="create" element={<SeasonLogForm />} />
                         </Route>
                     </Route>
                 </Routes>

--- a/src/components/season-logs/SeasonLogForm.jsx
+++ b/src/components/season-logs/SeasonLogForm.jsx
@@ -1,0 +1,24 @@
+import { useLocation, useNavigate } from "react-router-dom"
+import { createSeasonLog } from "../../dataManager/seasonLogs"
+
+export const SeasonLogForm = () => {
+    const location = useLocation()
+    const navigate = useNavigate()
+    const season = location.state?.season
+
+    const handleSubmit = () => {
+        createSeasonLog(season.id).then((newSeasonLogData) => {
+            if (newSeasonLogData) {
+                const newSeasonLogId = newSeasonLogData.id
+                navigate(`/season-logs`)
+            }
+        })
+    }
+
+    return (
+        <div>
+            <h3>Would you like to start a season log for Season #{season.season_number}?</h3>
+            <button onClick={handleSubmit}>START LOG</button>
+        </div>
+    )
+}

--- a/src/components/season-logs/SeasonLogsList.jsx
+++ b/src/components/season-logs/SeasonLogsList.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react"
 import { useAppContext } from "../../context/state"
 import { getSeasonLogs } from "../../dataManager/seasonLogs"
-import { Link, useParams } from "react-router-dom"
+import { Link } from "react-router-dom"
 
 export const SeasonLogsList = () => {
     const {token} = useAppContext()
@@ -28,7 +28,7 @@ export const SeasonLogsList = () => {
 
     return (
         <div>
-            <h3>Active Logs</h3>
+            <h3>Actively Watching</h3>
             {activeLogs?.map((log) => {
                 return(
                     <Link to={`/season-logs/${log.id}`} key={log.id}>
@@ -36,11 +36,18 @@ export const SeasonLogsList = () => {
                     </Link>
                 )
             })}
-            <h3>Completed Logs</h3>
-            <h3>Unlogged Seasons</h3>
+            <h3>Completed</h3>
+            {completedLogs?.map((log) => {
+                return (
+                    <Link to={`/season-logs/${log.id}`} key={log.id}>
+                        <div>Season #{log.season.season_number}</div>
+                    </Link>
+                )
+            })}
+            <h3>Unwatched Seasons</h3>
             {inactiveLogs?.map((season) => {
                 return(
-                    <Link to={`/season-logs/create`} key={season.id}>
+                    <Link to={`/season-logs/create`} key={season.id} state={{season: season}}>
                         <div>Season #{season.season_number}</div>
                     </Link> 
                 )

--- a/src/dataManager/seasonLogs.js
+++ b/src/dataManager/seasonLogs.js
@@ -15,3 +15,14 @@ export const getSeasonLogById = (id) => {
         }
     })
 }
+
+export const createSeasonLog = (id) => {
+    return fetchWithResponse(`season-logs`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Token ${localStorage.getItem('token')}`
+        },
+        body: JSON.stringify({"season_id": id})
+    }) 
+}


### PR DESCRIPTION
# Description
- Defined a SeasonLogForm component for a user to start a new season log
- Defined a createSeasonLog() fetch function in dataManagers/seasonLogs for POST requests to `/season-logs` with the season_id sent in the request body
- When a user clicks the START SEASON LOG button, a new season log is created along with the bulk creation of survivor logs for every survivor in that season

Fixes #25


## Type of change
- [x] New feature

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no errors

# How Did I Test This?

- [ ] Tested with Season 8 because season 8 cast of survivors exist in the database
- [ ] Successful POST request with new season log and expanded season in the response body
```json
{
    "id": 2,
    "status": "active",
    "season": {
        "id": 10,
        "season_number": 8,
        "name": "All-Stars",
        "location": "Panama",
        "start_date": "2004-02-01",
        "end_date": "2004-05-09",
        "is_current": false
    }
}
```
- [ ] Right now, application navigates back to the `/season-logs` route with the newly created season added to the end of the Active seasons list and removed from the Inactive list
- [ ] Verified that 18 Survivor Logs were added to the database with a season_log_id FK of the newly created season log & with the user_id FK of the logged in user