### PR TITLE
Created SurvivorCard component to be rendered in the SurvivorLogList …

### DIFF
--- a/src/components/seasonLogs/SeasonLogDetails.jsx
+++ b/src/components/seasonLogs/SeasonLogDetails.jsx
@@ -3,7 +3,7 @@ import { useLocation, useNavigate, useParams } from "react-router-dom"
 import { getSeasonLogById } from "../../dataManagers/seasonLogs"
 import { SurvivorLogList } from "../survivorLogs/survivorLogList"
 
-export const SeasonLogDetail = () => {
+export const SeasonLogDetails = () => {
     const { seasonLogId } = useParams()
     const location = useLocation()
     const navigate = useNavigate()

--- a/src/components/survivorLogs/SurvivorLogCard.jsx
+++ b/src/components/survivorLogs/SurvivorLogCard.jsx
@@ -1,0 +1,26 @@
+import "./Survivors.css"
+
+export const SurvivorLogCard = ({ survivorLog }) => {
+    const { survivor } = survivorLog
+    const placeholderImage = "https://place-hold.it/200x250/666/fff/000.jpg&text=No Image&fontsize=16"
+
+    return (
+        <div className="survivor-card">
+            <div className="survivor-image-container">
+                <img 
+                    src={survivor.img_url || placeholderImage} 
+                    alt={`${survivor.first_name} ${survivor.last_name}`}
+                    className="survivor-image"
+                />
+                {survivorLog.is_active && <div className="status-badge active">Active</div>}
+                {survivorLog.is_juror && <div className="status-badge jury">Jury</div>}
+            </div>
+            <div className="survivor-info">
+                <h3 className="survivor-name">
+                    {survivor.first_name} {survivor.last_name}
+                </h3>
+                <p className="survivor-age">Age: {survivor.age}</p>
+            </div>
+        </div>
+    )
+}

--- a/src/components/survivorLogs/SurvivorLogDetails.jsx
+++ b/src/components/survivorLogs/SurvivorLogDetails.jsx
@@ -1,0 +1,3 @@
+export const SurvivorLogDetails = () => {
+    
+}

--- a/src/components/survivorLogs/SurvivorLogDetails.jsx
+++ b/src/components/survivorLogs/SurvivorLogDetails.jsx
@@ -1,3 +1,90 @@
+import { useEffect, useState } from "react"
+import { useLocation, useNavigate, useParams } from "react-router-dom"
+import { SurvivorLogCard } from "./SurvivorLogCard"
+
 export const SurvivorLogDetails = () => {
+    const location = useLocation()
+    const navigate = useNavigate()
+    const { seasonLogId, survivorId} = useParams()
+
+    // Get the survivor log from state or set to null if not available
+    const [survivorLog, setSurvivorLog] = useState(location.state?.survivorLog || {})
+    const seasonLog = location.state?.seasonLog
     
+    // If needed, fetch the survivor log if accessing page directly
+
+    useEffect(() => {
+        if (!survivorLog && survivorId) {
+            // fetch survivor log here
+        }
+    }, [survivorId])
+
+    return (
+        <div className="p-4 max-w-7xl mx-auto">
+            <button 
+                onClick={() => navigate(`/season-logs/${seasonLogId}`)}
+                className="mb-6 text-blue-500 hover:text-blue-700 flex items-center"
+            >
+                ← Back to Season {seasonLog?.season?.season_number || ''} Survivors
+            </button>
+
+            {/* Top section with card and stats side by side */}
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+                {/* Left side - Smaller Survivor Card */}
+                <div className="details-card-container">
+                    <SurvivorLogCard survivorLog={survivorLog} />
+                </div>
+
+                {/* Right side - Stats Section */}
+                <div className="bg-white p-6 rounded-lg shadow-md h-full">
+                    <h2 className="text-2xl font-bold mb-4">Survivor Stats</h2>
+                    <div className="space-y-4">
+                        <div className="stat-group">
+                            <h3 className="text-lg font-semibold mb-2">Game Status</h3>
+                            <div className="stats-grid">
+                                <div className="stat-item">
+                                    <span className="stat-label">Current Status:</span>
+                                    <span className="stat-value">{survivorLog.is_active ? 'Active' : 'Inactive'}</span>
+                                </div>
+                                <div className="stat-item">
+                                    <span className="stat-label">Jury Member:</span>
+                                    <span className="stat-value">{survivorLog.is_juror ? 'Yes' : 'No'}</span>
+                                </div>
+                                {survivorLog.episode_voted_out && (
+                                    <div className="stat-item">
+                                        <span className="stat-label">Voted Out:</span>
+                                        <span className="stat-value">Episode {survivorLog.episode_voted_out}</span>
+                                    </div>
+                                )}
+                            </div>
+                        </div>
+
+                        {/* Placeholder for additional stats */}
+                        <div className="stat-group">
+                            <h3 className="text-lg font-semibold mb-2">Challenge Performance</h3>
+                            <div className="stats-grid">
+                                <div className="stat-item">
+                                    <span className="stat-label">Individual Immunity Wins:</span>
+                                    <span className="stat-value">0</span>
+                                </div>
+                                <div className="stat-item">
+                                    <span className="stat-label">Reward Challenges Won:</span>
+                                    <span className="stat-value">0</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            {/* Bottom section - Notes */}
+            <div className="bg-white p-6 rounded-lg shadow-md">
+                <h2 className="text-2xl font-bold mb-4">Notes</h2>
+                <textarea 
+                    className="w-full p-3 border rounded-md min-h-[150px] focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    placeholder="Add notes about this survivor..."
+                />
+            </div>
+        </div>
+    )
 }

--- a/src/components/survivorLogs/SurvivorLogList.jsx
+++ b/src/components/survivorLogs/SurvivorLogList.jsx
@@ -1,28 +1,35 @@
 import { useEffect, useState } from "react"
 import { getSurvivorLogs } from "../../dataManagers/survivorLogs"
 import { Link } from "react-router-dom"
+import { SurvivorLogCard } from "./SurvivorLogCard"
 
 export const SurvivorLogList = ({ seasonLog }) => {
     const [survivorLogs, setSurvivorLogs] = useState([])
+    
     const getAndSetSurvivorLogs = () => {
         getSurvivorLogs(seasonLog.id).then((survivorLogData) => {
             setSurvivorLogs(survivorLogData)
         })
     }
+
     useEffect(() => {
         getAndSetSurvivorLogs()
     }, [])
 
     return(
-        <>
-            <h3>Survivor Cards Here</h3>
-            {survivorLogs.map((survivor) => {
-                return (
-                    <Link to={`/season-logs/${seasonLog.id}/survivors/${survivor.id}`} key={survivor.id}>
-                        <div>{survivor.survivor.first_name}</div>
+        <div className="p-4">
+            <h2 className="text-2xl font-bold mb-6">Survivor Cards</h2>
+            <div className="survivor-grid">
+                {survivorLogs.map((survivorLog) => (
+                    <Link 
+                        to={`/season-logs/${seasonLog.id}/survivors/${survivorLog.id}`} 
+                        key={survivorLog.id}
+                        state={{ survivorLog, seasonLog }}
+                    >
+                        <SurvivorLogCard survivorLog={survivorLog} />
                     </Link>
-                )
-            })}
-        </>
+                ))}
+            </div>
+        </div>
     )
 }

--- a/src/components/survivorLogs/SurvivorLogList.jsx
+++ b/src/components/survivorLogs/SurvivorLogList.jsx
@@ -18,7 +18,7 @@ export const SurvivorLogList = ({ seasonLog }) => {
 
     return(
         <div className="p-4">
-            <h2 className="text-2xl font-bold mb-6">Survivor Cards</h2>
+            <h2 className="text-2xl font-bold mb-6">Survivors</h2>
             <div className="survivor-grid">
                 {survivorLogs.map((survivorLog) => (
                     <Link 

--- a/src/components/survivorLogs/Survivors.css
+++ b/src/components/survivorLogs/Survivors.css
@@ -95,3 +95,60 @@
         font-size: 0.9rem;
     }
 }
+
+
+.details-card-container .survivor-card {
+    max-width: 300px;  /* Smaller width for the detail view */
+    margin: 0 auto;
+    transform: none;  /* Disable hover transform if desired */
+}
+
+.details-card-container .survivor-image-container {
+    padding-top: 125%;  /* Maintain aspect ratio */
+}
+
+/* Stats styling */
+.stats-grid {
+    display: grid;
+    gap: 1rem;
+}
+
+.stat-group {
+    border-bottom: 1px solid #e5e7eb;
+    padding-bottom: 1rem;
+}
+
+.stat-group:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
+.stat-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.5rem 0;
+}
+
+.stat-label {
+    color: #4b5563;
+    font-weight: 500;
+}
+
+.stat-value {
+    color: #1f2937;
+    font-weight: 600;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+    .details-card-container .survivor-card {
+        max-width: 250px;  /* Even smaller on mobile */
+    }
+    
+    .stat-item {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.25rem;
+    }
+}

--- a/src/components/survivorLogs/Survivors.css
+++ b/src/components/survivorLogs/Survivors.css
@@ -1,0 +1,97 @@
+/* Survivors.css */
+.survivor-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+    gap: 2rem;
+    padding: 2rem;
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.survivor-card {
+    background: white;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    transition: transform 0.2s ease-in-out;
+    overflow: hidden;
+}
+
+.survivor-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}
+
+.survivor-image-container {
+    position: relative;
+    width: 100%;
+    padding-top: 125%; /* 5:4 aspect ratio */
+    overflow: hidden;
+}
+
+.survivor-image {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.survivor-info {
+    padding: 1rem;
+    text-align: center;
+}
+
+.survivor-name {
+    margin: 0;
+    font-size: 1.2rem;
+    font-weight: 600;
+    color: #333;
+}
+
+.survivor-age {
+    margin: 0.5rem 0 0;
+    color: #666;
+    font-size: 1rem;
+}
+
+.status-badge {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: white;
+}
+
+.status-badge.active {
+    background-color: #22c55e;
+}
+
+.status-badge.jury {
+    background-color: #6366f1;
+}
+
+@media (max-width: 768px) {
+    .survivor-grid {
+        grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+        gap: 1rem;
+        padding: 1rem;
+    }
+}
+
+@media (max-width: 480px) {
+    .survivor-grid {
+        grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    }
+    
+    .survivor-name {
+        font-size: 1rem;
+    }
+    
+    .survivor-age {
+        font-size: 0.9rem;
+    }
+}

--- a/src/dataManagers/survivorLogs.js
+++ b/src/dataManagers/survivorLogs.js
@@ -1,9 +1,13 @@
 import { fetchWithResponse } from "./fetcher"
 
-export const getSurvivorLogs = (id) => {
-    return fetchWithResponse(`/season-logs/${id}/survivors`, {
+export const getSurvivorLogs = (seasonLogId) => {
+    return fetchWithResponse(`/season-logs/${seasonLogId}/survivors`, {
         headers: {
             Authorization: `Token ${localStorage.getItem('token')}`
         }        
     })
+}
+
+export const getSurvivorLogById = () => {
+    return fetchWithResponse(`/season-logs/{seasonLogId}`)
 }

--- a/src/views/ApplicationViews.jsx
+++ b/src/views/ApplicationViews.jsx
@@ -7,6 +7,7 @@ import { SeasonLogsList } from "../components/seasonLogs/SeasonLogsList"
 import { NavBar } from "../components/navbar/Navbar"
 import { SeasonLogDetails } from "../components/seasonLogs/SeasonLogDetails"
 import { SeasonLogForm } from "../components/seasonLogs/SeasonLogForm"
+import { SurvivorLogDetails } from "../components/survivorLogs/SurvivorLogDetails"
 
 export const ApplicationViews = () => {
     return (
@@ -23,7 +24,7 @@ export const ApplicationViews = () => {
                             <Route path="create" element={<SeasonLogForm />} />
                             <Route path=":seasonLogId" >
                                 <Route index element={<SeasonLogDetails />}/>
-                                <Route path="survivors/:survivorId" element={<>Survivor Details and Notes here</>} />
+                                <Route path="survivors/:survivorId" element={<SurvivorLogDetails />} />
                             </Route>
                         </Route>
                     </Route>

--- a/src/views/ApplicationViews.jsx
+++ b/src/views/ApplicationViews.jsx
@@ -5,7 +5,7 @@ import { Authorized } from "./Authorized"
 import Home from "../pages/Home"
 import { SeasonLogsList } from "../components/seasonLogs/SeasonLogsList"
 import { NavBar } from "../components/navbar/Navbar"
-import { SeasonLogDetail } from "../components/seasonLogs/SeasonLogDetail"
+import { SeasonLogDetails } from "../components/seasonLogs/SeasonLogDetails"
 import { SeasonLogForm } from "../components/seasonLogs/SeasonLogForm"
 
 export const ApplicationViews = () => {
@@ -22,7 +22,7 @@ export const ApplicationViews = () => {
                             <Route index element={<SeasonLogsList />} />
                             <Route path="create" element={<SeasonLogForm />} />
                             <Route path=":seasonLogId" >
-                                <Route index element={<SeasonLogDetail />}/>
+                                <Route index element={<SeasonLogDetails />}/>
                                 <Route path="survivors/:survivorId" element={<>Survivor Details and Notes here</>} />
                             </Route>
                         </Route>


### PR DESCRIPTION
…| set up SurvivorCards to Link to SurvivorDetails component

# Description
- SurvivorLogDetails component when a survivor card is clicked on in the SurvivorLogList view
- Set up client route to `/survivor-logs/{survivor log id}/survivors/{survivor log id}` to render the `<SeasonLogDetails />` component
- Added styling and placeholder containers for stats and notes sections.

Fixes #28

## Type of change

Please delete options that are not relevant.
- [x] New feature

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no errors **Need to address routing issues when trying to go back to a previous view**

# How Did I Test This?

- [x] Logged in as user 6
- [x] Clicked on season # 47 log
- [x] Clicked on a survivor card in the list of season 47 survivors
- [x] Survivor card, stats container, and notes container display properly