### PR TITLE
Created SeasonLogFilterBar component for toggling season log views

### DIFF
--- a/src/components/episodeLogs/EpisodeLogList.jsx
+++ b/src/components/episodeLogs/EpisodeLogList.jsx
@@ -1,0 +1,12 @@
+import { useOutletContext } from "react-router-dom"
+
+export const EpisodeLogList = () => {
+    const { seasonLog } = useOutletContext()
+    
+    return (
+        <div>
+            <h3>Episodes for Season {seasonLog.season.season_number}</h3>
+            {/* Episode list implementation will go here */}
+        </div>
+    )
+}

--- a/src/components/seasonLogs/SeasonLogDetails.jsx
+++ b/src/components/seasonLogs/SeasonLogDetails.jsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react"
-import { useLocation, useNavigate, useParams } from "react-router-dom"
+import { Outlet, useLocation, useNavigate, useParams } from "react-router-dom"
 import { getSeasonLogById } from "../../dataManagers/seasonLogs"
 import { SurvivorLogList } from "../survivorLogs/survivorLogList"
+import { SeasonLogFilter } from "./SeasonLogFilterBar"
 
 export const SeasonLogDetails = () => {
     const { seasonLogId } = useParams()
@@ -22,12 +23,21 @@ export const SeasonLogDetails = () => {
         }
     }, [seasonLogId])
 
+    // if (!seasonLog) return <div>Loading...</div>
+
     return (
-        <>
-            <div>
+        <div className="container mx-auto px-4">
+            <h2 className="text-2xl font-bold text-center my-4">
                 Season #{seasonLog.season.season_number} Log
-            </div>
-            <SurvivorLogList seasonLog={seasonLog}/>
-        </>
+            </h2>
+            
+            <SeasonLogFilter />
+            
+            {location.pathname === `/season-logs/${seasonLogId}` ? (
+                <SurvivorLogList seasonLog={seasonLog} />
+            ) : (
+                <Outlet context={{ seasonLog }} />
+            )}
+        </div>
     )
 }

--- a/src/components/seasonLogs/SeasonLogFilterBar.jsx
+++ b/src/components/seasonLogs/SeasonLogFilterBar.jsx
@@ -1,0 +1,45 @@
+import { Link, useLocation, useParams } from "react-router-dom"
+
+export const SeasonLogFilter = () => {
+    const location = useLocation()
+    const { seasonLogId } = useParams()
+
+    // Get the current filter from the URL
+    const currentPath = location.pathname
+    const basePath = `/season-logs/${seasonLogId}`
+
+    return (
+        <div className="flex justify-center space-x-4 my-4">
+          <Link
+            to={basePath}
+            className={`px-4 py-2 rounded-lg transition-colors ${
+              currentPath === basePath
+                ? 'bg-blue-600 text-white'
+                : 'bg-gray-200 hover:bg-gray-300 text-gray-700'
+            }`}
+          >
+            Survivors
+          </Link>
+          <Link
+            to={`${basePath}/episodes`}
+            className={`px-4 py-2 rounded-lg transition-colors ${
+              currentPath.includes('/episodes')
+                ? 'bg-blue-600 text-white'
+                : 'bg-gray-200 hover:bg-gray-300 text-gray-700'
+            }`}
+          >
+            Episodes
+          </Link>
+          <Link
+            to={`${basePath}/favorites`}
+            className={`px-4 py-2 rounded-lg transition-colors ${
+              currentPath.includes('/favorites')
+                ? 'bg-blue-600 text-white'
+                : 'bg-gray-200 hover:bg-gray-300 text-gray-700'
+            }`}
+          >
+            Favorites
+          </Link>
+        </div>
+    )
+}  

--- a/src/components/survivorLogs/FavoriteSurvivorList.jsx
+++ b/src/components/survivorLogs/FavoriteSurvivorList.jsx
@@ -1,0 +1,12 @@
+import { useOutletContext } from "react-router-dom"
+
+export const FavoriteSurvivorList = () => {
+    const { seasonLog } = useOutletContext()
+    
+    return (
+        <div>
+            <h3>Favorite Survivors for Season {seasonLog.season.season_number}</h3>
+            {/* Favorites list implementation will go here */}
+        </div>
+    )
+}

--- a/src/views/ApplicationViews.jsx
+++ b/src/views/ApplicationViews.jsx
@@ -22,8 +22,10 @@ export const ApplicationViews = () => {
                         <Route path="/season-logs"> 
                             <Route index element={<SeasonLogsList />} />
                             <Route path="create" element={<SeasonLogForm />} />
-                            <Route path=":seasonLogId" >
-                                <Route index element={<SeasonLogDetails />}/>
+                            <Route path=":seasonLogId">
+                                <Route index element={<SeasonLogDetails />} />
+                                <Route path="episodes" element={<SeasonLogDetails />} />
+                                <Route path="favorites" element={<SeasonLogDetails />} />
                                 <Route path="survivors/:survivorLogId" element={<SurvivorLogDetails />} />
                             </Route>
                         </Route>


### PR DESCRIPTION
# Description
- SeasonLogFilterBar component for toggling between Survivor Logs, Episode Logs, and Favorite Survivors in a given season log
- Set up placeholder routes and components for the EpisodeLogList and FavoriteSurvivorList
- Utilized react router dom's useOutletContext() hook
- Refactored ApplicationViews routes and added placeholder routes for rendering <EpisodeLogList /> and <FavoriteSurvivorList /> components

Fixes # 38

## Type of change
- [x] New feature

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no errors

# How Did I Test This?

- [x] Navigated to Seasons List
- [x] Clicked on an Active Season Log
- [x] Verified that the app routed to Survivors tab at the index of a season log details view
- [x] toggled between "Survivors", "Episodes", and "Favorites" without errors